### PR TITLE
Add right-click-context-click-menu for mouse click event

### DIFF
--- a/right-click-context.el
+++ b/right-click-context.el
@@ -69,9 +69,16 @@
   :group 'right-click-context
   :type 'string)
 
+(defcustom right-click-context-mouse-set-point-before-open-menu 'not-region
+  "Control the position of the mouse pointer before opening the menu."
+  :group 'right-click-context
+  :type '(choice (const :tag "When not Region activated" 'not-region)
+                 (const :tag "Always set cursor to mouse pointer" 'always)
+                 (const :tag "Not set cursor to mouse pointer" nil)))
+
 (defvar right-click-context-mode-map
   (let ((map (make-sparse-keymap)))
-    (define-key map (kbd "<mouse-3>") #'right-click-context-menu)
+    (define-key map (kbd "<mouse-3>") #'right-click-context-click-menu)
     map)
   "Keymap used in right-click-context-mode.")
 
@@ -191,10 +198,19 @@ You probably want to just add follows code to your .emacs file (init.el).
   :group 'right-click-context)
 
 ;;;###autoload
+(defun right-click-context-click-menu (event)
+  "Open Right Click Context menu by Mouse Click `EVENT'."
+  (interactive "e")
+  (when (or (eq right-click-context-mouse-set-point-before-open-menu 'always)
+            (and (null mark-active)
+                 (eq right-click-context-mouse-set-point-before-open-menu 'not-region)))
+    (call-interactively #'mouse-set-point))
+  (right-click-context-menu))
+
+;;;###autoload
 (defun right-click-context-menu ()
   "Open Right Click Context menu."
   (interactive)
-  (call-interactively #'mouse-set-point)
   (let ((value (popup-cascade-menu (right-click-context--build-menu-for-popup-el (right-click-context--menu-tree) nil))))
     (when value
       (if (symbolp value)


### PR DESCRIPTION
refs #5

`(call-interactively # 'mouse-set-point)` has problems that depend on the mouse device and causes an error on keyboard input.  There are several ways to handle this, but the easiest and most obvious is to split up the commands for the click. It does not break compatibility.