### PR TITLE
test(ci): Add CI using Eask

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,43 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        emacs-version:
+          - 26.3
+          - 27.2
+          - 28.1
+          - snapshot
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: jcs090218/setup-emacs@master
+      with:
+        version: ${{ matrix.emacs-version }}
+
+    - uses: actions/setup-node@v2
+      with:
+        node-version: '14'
+
+    - uses: emacs-eask/setup-eask@master
+      with:
+        version: 'snapshot'
+
+    - name: Run tests
+      run:
+        make ci

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *-autoloads.el
 *.elc
-/.cask
+/.eask
+/dist

--- a/Eask
+++ b/Eask
@@ -7,3 +7,5 @@
 (depends-on "emacs" "24.3")
 (depends-on "popup")
 (depends-on "ordinal")
+
+(setq network-security-level 'low)  ; see https://github.com/jcs090218/setup-emacs-windows/issues/156#issuecomment-932956432

--- a/Eask
+++ b/Eask
@@ -1,5 +1,9 @@
-(source gnu)
-(source melpa)
-
 (package "right-click-context" "0.4.0" "Right Click Context menu")
 (package-file "right-click-context.el")
+
+(source "gnu")
+(source "melpa")
+
+(depends-on "emacs" "24.3")
+(depends-on "popup")
+(depends-on "ordinal")

--- a/Makefile
+++ b/Makefile
@@ -1,32 +1,30 @@
-CASK ?= cask
+EASK ?= eask
 EMACS ?= emacs
-ELS = right-click-context.el
-AUTOLOADS = right-click-context-autoload.el
-ELCS = $(ELS:.el=.elc)
 
-.cask: Cask
-	CASK
+package:
+	@echo "Packaging..."
+	$(EASK) package
 
-%.elc: %.el .cask
-	$(EMACS) -Q -batch -L . --eval \
-	"(let ((default-directory (expand-file-name \".cask\" default-directory))) \
-           (normal-top-level-add-subdirs-to-load-path))" \
-       -f batch-byte-compile $<
+install:
+	@echo "Installing..."
+	$(EASK) install
 
-all: autoloads $(ELCS)
+compile:
+	@echo "Compiling..."
+	$(EASK) compile
 
-autoloads: $(AUTOLOADS)
+all: autoloads
 
-$(AUTOLOADS): $(ELCS)
-	$(EMACS) -Q -batch -L . --eval \
-	"(progn \
-           (require 'package) \
-	   (package-generate-autoloads \"right-click-context\" default-directory))"
+autoloads:
+	$(EASK) autoloads
 
 clean:
-	-rm -f $(ELCS) $(AUTOLOADS)
+	$(EASK) clean-elc
+	-rm -f $(AUTOLOADS)
 
 clobber: clean
-	-rm -rf .cask
+	$(EASK) clean
 
 .PHONY: all autoloads clean clobber
+
+ci: clean package install compile


### PR DESCRIPTION
Hi! :D 

As always, thanks for this amazing package! ❤️ I wonder if you are willing to add basic CI test for this repository, hence I have this PR opened. This patch replaced Cask with Eask which is another alternative similar to Cask. This patch should cut down the complexity in Makefile and make the tests a lot easier for users. :D 

I have written a blog post in [Why Eask, and not Cask?](https://jcs090218.github.io/blog/emacs-eask/#-then-why-eask-and-not-cask) should explain the benefits of why Eask over Cask! Hope this is helpful! :) 